### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that provides LLM tool calls to interact with an Obsidian vault through a local REST API. This server acts as a bridge between MCP clients (like Claude Desktop, VS Code, etc.) and the Obsidian Local REST API.
 
+<a href="https://glama.ai/mcp/servers/@j-shelfwood/obsidian-local-rest-api-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@j-shelfwood/obsidian-local-rest-api-mcp/badge" alt="Obsidian Local REST API Server MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js 18+ or Bun runtime


### PR DESCRIPTION
This PR adds a badge for the [Obsidian Local REST API MCP Server](https://glama.ai/mcp/servers/@j-shelfwood/obsidian-local-rest-api-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@j-shelfwood/obsidian-local-rest-api-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@j-shelfwood/obsidian-local-rest-api-mcp/badge" alt="Obsidian Local REST API Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.